### PR TITLE
Add User API routes

### DIFF
--- a/api/v1/views/__init__.py
+++ b/api/v1/views/__init__.py
@@ -3,3 +3,4 @@ from flask import Blueprint
 app_views = Blueprint('app_views', __name__, url_prefix = '/api/v1')
 from api.v1.views.index import *
 from api.v1.views.states import *
+from api.v1.views.users import *

--- a/api/v1/views/__init__.py
+++ b/api/v1/views/__init__.py
@@ -4,3 +4,4 @@ app_views = Blueprint('app_views', __name__, url_prefix = '/api/v1')
 from api.v1.views.index import *
 from api.v1.views.states import *
 from api.v1.views.users import *
+from api.v1.views.places import *

--- a/api/v1/views/places.py
+++ b/api/v1/views/places.py
@@ -1,0 +1,83 @@
+#!/usr/bin/python3
+""" Place objects RESTful API. """
+from flask import jsonify, request, abort
+from models import storage
+from models.city import City
+from models.place import Place
+from models.user import User
+from api.v1.views import app_views
+
+"""HTTP methods"""
+G = 'GET'
+P = 'POST'
+D = 'DELETE'
+Pu = 'PUT'
+
+
+@app_views.route("/cities/<city_id>/places", methods=[G], strict_slashes=False)
+def get_places(city_id):
+    """API endpoint that delivers all Place objects in a city"""
+    checked_city = storage.get(City, city_id)
+    if not checked_city:
+        abort(404)
+    list_of_places = [place.to_dict() for place in checked_city.places]
+    return jsonify(list_of_places)
+
+
+@app_views.route("/cities/<city_id>/places", methods=[P], strict_slashes=False)
+def create_place(city_id):
+    """API endpoint that creates a new Place object in a city"""
+    checked_city = storage.get(City, city_id)
+    if not checked_city:
+        abort(404)
+    HTTP_body = request.get_json(silent=True)
+    if not HTTP_body:
+        abort(400, 'Not a JSON')
+    if 'user_id' not in HTTP_body:
+        abort(400, 'Missing user_id')
+    checked_user = storage.get(User, HTTP_body['user_id'])
+    if not checked_user:
+        abort(404)
+    if 'name' not in HTTP_body:
+        abort(400, 'Missing name')
+    latest_place = Place(**HTTP_body)
+    storage.new(latest_place)
+    storage.save()
+    return jsonify(latest_place.to_dict()), 201
+
+
+@app_views.route("/places/<place_id>", methods=[G], strict_slashes=False)
+def get_place(place_id):
+    """API endpoint that delivers a specific Place object"""
+    place = storage.get(Place, place_id)
+    if not place:
+        abort(404)
+    return jsonify(place.to_dict())
+
+
+@app_views.route("/places/<place_id>", methods=[D], strict_slashes=False)
+def delete_place(place_id):
+    """API endpoint that deletes a specific Place object"""
+    place = storage.get(Place, place_id)
+    if not place:
+        abort(404)
+    storage.delete(place)
+    storage.save()
+    return jsonify({}), 200
+
+
+@app_views.route("/places/<place_id>", methods=[Pu], strict_slashes=False)
+def update_place(place_id):
+    """API endpoint that updates a specific Place object"""
+    place = storage.get(Place, place_id)
+    if not place:
+        abort(404)
+    HTTP_body = request.get_json(silent=True)
+    if not HTTP_body:
+        abort(400, 'Not a JSON')
+    ignoring_keys = ['id', 'user_id', 'city_id', 'created_at', 'updated_at']
+    for key, value in HTTP_body.items():
+        if key not in ignoring_keys:
+            setattr(place, key, value)
+    storage.save()
+    return jsonify(place.to_dict()), 200

--- a/api/v1/views/users.py
+++ b/api/v1/views/users.py
@@ -1,0 +1,67 @@
+#!/usr/bin/python3
+""" User objects RESTful API. """
+from flask import jsonify, request, abort
+from models import storage
+from models.user import User
+from api.v1.views import app_views
+
+
+@app_views.route("/users", methods=['GET'], strict_slashes=False)
+def get_users():
+    """API endpoint that delivers all User objects"""
+    users = storage.all(User).values()
+    list_of_users = [user.to_dict() for user in users]
+    return jsonify(list_of_users)
+
+@app_views.route("/users", methods=["POST"], strict_slashes=False)
+def create_user():
+    """API endpoint that creates a new User object"""
+    HTTP_body = request.get_json(silent=True)
+    if not HTTP_body:
+        abort(400, 'Not a JSON')
+    if 'email' not in HTTP_body:
+        abort(400, 'Missing email')
+    if 'password' not in HTTP_body:
+        abort(400, 'Missing password')
+    latest_user = User(**HTTP_body)
+    storage.new(latest_user)
+    storage.save()
+    return jsonify(latest_user.to_dict()), 201
+
+
+@app_views.route("/users/<user_id>", methods=['GET'], strict_slashes=False)
+def get_user(user_id):
+    """API endpoint that delivers a single User object"""
+    user = storage.get(User, user_id)
+    if not user:
+        abort(404)
+    return jsonify(user.to_dict())
+
+
+@app_views.route("/users/<user_id>", methods=['DELETE'], strict_slashes=False)
+def delete_user(user_id):
+    """API endpoint that deletes a User object"""
+    user = storage.get(User, user_id)
+    if not user:
+        abort(404)
+    storage.delete(user)
+    storage.save()
+    return jsonify({}), 200
+
+
+@app.route("/users/<user_id", methods=['PUT', strict_slashes=False])
+def update_user(user_id):
+    """API endpoint that updates a User object"""
+    user = storage.get(User, user_id)
+    if not user:
+        abort(404)
+    HTTP_body = request.get_json(silent=True)
+    if not HTTP_body:
+        abort(400, 'Not a JSON')
+    ignoring_keys = ['id', 'email', 'created_at', 'updated_at']
+    for key, value in HTTP_body.items():
+        if key not in ignoring_keys:
+            setattr(user, key, value)
+    storage.save()
+    return jsonify(user.to_dict()), 200
+

--- a/api/v1/views/users.py
+++ b/api/v1/views/users.py
@@ -13,6 +13,7 @@ def get_users():
     list_of_users = [user.to_dict() for user in users]
     return jsonify(list_of_users)
 
+
 @app_views.route("/users", methods=["POST"], strict_slashes=False)
 def create_user():
     """API endpoint that creates a new User object"""
@@ -49,7 +50,7 @@ def delete_user(user_id):
     return jsonify({}), 200
 
 
-@app.route("/users/<user_id", methods=['PUT', strict_slashes=False])
+@app.route("/users/<user_id", methods=['PUT'], strict_slashes=False)
 def update_user(user_id):
     """API endpoint that updates a User object"""
     user = storage.get(User, user_id)
@@ -64,4 +65,3 @@ def update_user(user_id):
             setattr(user, key, value)
     storage.save()
     return jsonify(user.to_dict()), 200
-


### PR DESCRIPTION
Add the following API routes:
GET /api/v1/users - returns a list of all User objects in storage
POST /api/v1/users - creates a new User object and saves it to storage
GET /api/v1/users/<user_id> - returns the User object at the specified id
DELETE /api/v1/users/<user_id> - deletes the User object at the specified id
PUT /api/v1/users/<user_id> - updates the User object at the specified id with the data provided by the HTTP request